### PR TITLE
fix - could not build url

### DIFF
--- a/rest-server-v2.py
+++ b/rest-server-v2.py
@@ -44,7 +44,7 @@ task_fields = {
     'title': fields.String,
     'description': fields.String,
     'done': fields.Boolean,
-    'uri': fields.Url('task')
+    'uri': fields.Url('tasks')
 }
 
 


### PR DESCRIPTION
`Could not build url for endpoint 'task' with values ['description', 'done', 'id', 'title']. Did you mean 'tasks' instead?`

Changed `task` to `tasks` for `uri` in `task_fields` to build uri.