### PR TITLE
Added headers to all responses, to enable requests with credentials.

### DIFF
--- a/rest-server.py
+++ b/rest-server.py
@@ -57,6 +57,13 @@ def make_public_task(task):
     return new_task
 
 
+@app.after_request
+def after_request(response):
+    response.headers.add('Access-Control-Allow-Origin', request.origin)
+    response.headers.add('Access-Control-Allow-Headers', 'Content-Type,Authorization')
+    return response
+
+
 @app.route('/todo/api/v1.0/tasks', methods=['GET'])
 @auth.login_required
 def get_tasks():


### PR DESCRIPTION
This is in relation to my logged issue #24 
As suggested by @AngelMunoz in a previous issue;
https://github.com/miguelgrinberg/REST-tutorial/issues/4#issuecomment-123515351
I added a function to insert the two needed headers (first two suggested above) to every response from the app. Instead of allowing all origins ("*") it only allows request.origin.

I hope this does not cause a security issue, but lack the knowledge to judge if it is safe enough for inclusion in the project.